### PR TITLE
API result parsing was breaking over a trailing space in 'simple ' key

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -35,7 +35,7 @@ function clayton_api_action_delete() {
 	if( !yourls_is_shorturl( $shorturl ) ) {
 		return array(
 			'statusCode' => 404,
-			'simple '    => 'Error: short URL not found',
+			'simple'    => 'Error: short URL not found',
 			'message'    => 'error: not found',
 		);	
 	}


### PR DESCRIPTION
API result parsing was breaking over a trailing space in 'simple ' key
